### PR TITLE
fix: Use 'toLocaleString' instead of 'reg-ex'

### DIFF
--- a/src/components/container/VehicleCoverage.tsx
+++ b/src/components/container/VehicleCoverage.tsx
@@ -14,8 +14,12 @@ import {
 //   return Math.round(Math.random() * (max - min) + min);
 // }
 
+// export function numberWithCommas(x: number): string {
+//   return x.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
+// }
+
 export function numberWithCommas(x: number): string {
-  return x.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
+  return x.toLocaleString();
 }
 
 const VehicleCoverageContainer = () => {


### PR DESCRIPTION
Use the 'toLocaleString' function instead of regular-expression to support old browsers versions.